### PR TITLE
add form_translation support

### DIFF
--- a/lib/cruddler/controller.rb
+++ b/lib/cruddler/controller.rb
@@ -72,6 +72,11 @@ module Cruddler::Controller
       end
     elsif permit_params
       define_method "#{parameter_name}_params" do
+        if(klass.respond_to?(:translated_attrs))
+          permit_params = Array(permit_params).flatten
+          translatable_attrs = klass.translated_attrs.select{|a| permit_params.include?(a)}
+          permit_params += klass.translation_names_for(translatable_attrs)
+        end
         params.required(parameter_name.to_sym).permit(permit_params)
       end
     end


### PR DESCRIPTION
This adds support for [FormTranslation](https://github.com/crunch09/form_translation). Needed paramaters will automatically be added to the `permit_params` option.
